### PR TITLE
fix: Add CNAME file

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+gribnau.dev


### PR DESCRIPTION
Necessary for GitHub custom domain: otherwise we need to reset the custom domain on every publish